### PR TITLE
[feature] navigation back button으로 되돌리기 및 navigation title 빈 값 추가

### DIFF
--- a/HaveAGoodHabit/HaveAGoodHabit/View/HabitDetailView.swift
+++ b/HaveAGoodHabit/HaveAGoodHabit/View/HabitDetailView.swift
@@ -41,18 +41,10 @@ struct HabitDetailView: View {
                     }
             }
         }
-        .navigationBarBackButtonHidden()
         .scrollIndicators(.hidden)
         .padding(.horizontal, 8)
         .background(Color(.secondarySystemBackground))
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                Button {
-                    dismiss()
-                } label: {
-                    Image(systemName: "chevron.left")
-                }
-            }
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
                     Button("수정") {

--- a/HaveAGoodHabit/HaveAGoodHabit/View/HabitListView.swift
+++ b/HaveAGoodHabit/HaveAGoodHabit/View/HabitListView.swift
@@ -39,6 +39,7 @@ struct HabitListView: View {
                     .background(Color(.secondarySystemBackground))
                 }
             }
+            .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .principal) {

--- a/HaveAGoodHabit/HaveAGoodHabit/View/SettingView.swift
+++ b/HaveAGoodHabit/HaveAGoodHabit/View/SettingView.swift
@@ -18,16 +18,6 @@ struct SettingView: View {
         }
         .navigationTitle("설정")
         .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden()
-        .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                Button {
-                    dismiss()
-                } label: {
-                    Image(systemName: "chevron.left")
-                }
-            }
-        }
     }
 }
 


### PR DESCRIPTION
toolbar로 백 버튼 커스텀을 다시 navigation 백 버튼으로 되돌림
- 커스텀 백 버튼으로는 이전 화면 이동 스와이프가 동작하지 않기 때문
- 상위 navigation view에 navigation title 빈 값("")을 추가하여 back button 텍스트가 보이지 않게 구현